### PR TITLE
Add LTE to "config_radio_access_family" string

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -231,7 +231,7 @@
          Empty is viewed as "all".  Only used on devices which
          don't support RIL_REQUEST_GET_RADIO_CAPABILITY
          format is UMTS|LTE|... -->
-    <string translatable="false" name="config_radio_access_family">GSM|WCDMA</string>
+    <string translatable="false" name="config_radio_access_family">GSM|WCDMA|LTE</string>
 
     <!-- Set to true to add links to Cell Broadcast app from Settings and MMS app. -->
     <bool name="config_cellBroadcastAppLinks">true</bool>


### PR DESCRIPTION
The Nexus 4 is capable of LTE data using the correct modem image.  The ability to switch to LTE was supported in CM12, CM11, and CM10 (at a minimum).  Simply adding this feature back.

Change was tested on an unofficial build of the 030816 mako nightly.  Switching radio to "LTE Only", and then to "LTE/GSM (auto)" results in LTE data becoming enabled.
